### PR TITLE
Implementation of arithmetic functions in integer arithmetic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build/
+/CMakeFiles/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "compare": "c",
+        "cstdint": "c",
+        "chrono": "c",
+        "functional": "c"
+    }
+}

--- a/lib/routines/builtin/__ashlsi3.c
+++ b/lib/routines/builtin/__ashlsi3.c
@@ -1,0 +1,8 @@
+int __ashlsi3(int a, int b) {
+    int result = a;
+
+    for (int i = 0; i < b; i++)
+    {
+        result = result * 2;
+    }
+}

--- a/lib/routines/builtin/__mulsi3.c
+++ b/lib/routines/builtin/__mulsi3.c
@@ -1,0 +1,57 @@
+void separate_bases(int number, short parts[2]) 
+{
+    int result;
+    int rem;
+
+    // Divide the number successively by 65536 and store the remainders
+    for (int i = 0; i < 2; ++i) 
+    {
+        // x86_div64_32(number, 65536, &result, &rem);
+        
+        result = number / 65536;
+        rem = number % 65536;
+
+        parts[i] = (short)(rem);
+        number = result;
+    }
+}
+
+short multiply(short a, short n)
+{
+    short result = 0;
+
+    for (short i = 0; i < n; i++)
+    {
+        result = result + a;
+    }
+
+    return result;
+}
+
+int __mulsi3(int a, int b) {
+    short first_factor_digits[2];
+    short second_factor_digits[2];
+
+    short m_digits[2];
+    short c_digits[2];
+
+    int M = 0;
+    int C = 0;
+
+    separate_bases(a, first_factor_digits);
+    separate_bases(b, second_factor_digits);
+
+    for (short i = 0; i < 2; i++)
+    {
+        M = first_factor_digits[0] * second_factor_digits[0] + C;
+
+        int rem;
+        //x86_div64_32(M, 65536, &C, &rem);
+        
+        rem = M % 65536;
+
+        c_digits[i] = (short)rem;
+    }
+
+    return M;
+}


### PR DESCRIPTION
**THIS PULL REQUEST IS DRAFT! DO NOT MERGE, DO NOT CLOSE! MERGE WHEN EVERY FUNCTION IS IMPLEMENTED FROM TODO LIST AND OPTIMIZED ENOUGH!**

Link for function explanations: https://gcc.gnu.org/onlinedocs/gccint/Integer-library-routines.html#Arithmetic-functions

TODO:
- [ ] `__ashlsi3`
  - [x] int, int
  - [ ] long, int
  - [ ] long long, int
- [ ] `__ashrsi3`
- [ ] `__divsi3`
- [ ] `__lshrsi3`
- [ ] `__modsi`
- [ ] `__mulsi3`
  - [x] int, int (big optimizations needed)
  - [ ] long, int
  - [ ] long long, int
- [ ] `__negdi2`
- [ ] `__udivsi3`
- [ ] `__udivmoddi4`
- [ ] `__umodsi3`

Possibility: implement #ifdef to exit from function if hardware supports that function.